### PR TITLE
Make eq() value equivalence, is() referential equality

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.js"],
+  "include": ["dist/*.js"],
   "lines": 100,
   "statements": 100,
   "functions": 100

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # assert
 
-Strongly typed, curried test assertions.
+Strongly typed, curried test assertions. Use with any test framework that understands assertions that throw.
 
 ```js
-import { assert, eq } from '@briancavalier/assert'
+import { eq, is, assert } from '@briancavalier/assert'
 
 it('should be true', () => {
   assert(true)
 })
 
 it('should be equal', () => {
-  eq(123, 123)
+  is(123, 123)
 })
 
-it('should eventually be 123 via partial application', () => {
-  return Promise.resolve(123)
-    .then(eq(123))
+it('should eventually be equivalent via partial application', () => {
+  const expected = { name: 'Abe' }
+  return Promise.resolve({ name: 'Abe' })
+    .then(eq(expected))
 })
 ```
 
@@ -33,22 +34,43 @@ All functions are curried.
 
 ### eq :: a &rarr; a &rarr; a
 
-Assert expected === actual.  If so, return actual, otherwise throw AssertionError.
+Assert _value equivalence_.  Compares primitives by `===` and non-primitives (objects, arrays, etc) structurally.  Returns the second arg if the two values are equivalent, otherwise throws AssertionError.
 
 ```js
 eq(1, 1) //> 1
-eq(2, 1) //> AssertionError: 2 !== 1
+eq({ a: 'a' }, { a: 'a' }) //> { a: 'a' }
+eq([1, 2, 3], [1, 2, 3]) //> [1, 2, 3]
+eq([{ a: 'a' }, { b: 'b' }], [{ a: 'a' }, { b: 'b'}]) //> [{ a: 'a' }, { b: 'b'}]
+
+eq(2, 1) //> AssertionError
+eq([1, 2, 3], [1, 2]) //> AssertionError
+eq({ a: 'a' }, { a: 'b' }) //> AssertionError
+eq([{ a: 'a' }, { b: 'b' }], [{ a: 'a' }, { b: 'b'}]) //> AssertionError
+```
+
+### is :: a &rarr; a &rarr& a
+
+Assert _referential equivalence_.  Compares args by `===`.  Returns the second arg if the two values are `===`, otherwise throws AssertionError.
+
+```js
+is(1, 1) //> 1
+
+is(2, 1) //> AssertionError
+is({ a: 'a' }, { a: 'a' }) //> AssertionError
+is([1, 2, 3], [1, 2, 3]) //> AssertionError
 ```
 
 ### assert :: boolean &rarr; boolean
 
-Assert b is true. If so, return b, otherwise throw AssertionError.
+Assert _strictly_ `true`. If so, return true, otherwise throws AssertionError.
 
 ```js
 assert(true) //> true
 assert(1 === 1) //> true
-assert(false) //> AssertionError: false !== true
-assert(1 === '1') //> AssertionError: false !== true
+
+assert(false) //> AssertionError
+assert(1 === '1') //> AssertionError
+assert(1) //> AssertionError (1 !== true)
 ```
 
 ### fail :: string &rarr; void

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "scripts": {
     "commit": "northbrook commit",
-    "test": "npm run test:lint && npm run test:unit && npm run test:flow",
-    "test:unit": "nyc northbrook mocha",
+    "test": "npm run test:lint && npm run build:dist && npm run test:unit && npm run test:flow",
+    "test:unit": "nyc -s northbrook mocha",
     "test:lint": "northbrook eslint",
     "test:flow": "flow check",
     "build": "npm run build:dist && npm run build:flow && npm run build:ts",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "@most/prelude": "^1.4.1",
-    "lodash.isequal": "^4.5.0"
+    "lodash-es": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rollup-plugin-node-resolve": "^2.0.0"
   },
   "dependencies": {
-    "@most/prelude": "^1.4.1"
+    "@most/prelude": "^1.4.1",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/src/AssertionError.js
+++ b/src/AssertionError.js
@@ -3,11 +3,6 @@ export class AssertionError extends Error {
     super(message)
     this.name = 'AssertionError'
     this.message = message
-
-    /* istanbul ignore else */
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this)
-    }
   }
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,14 @@
 export function eq<A> (expected: A, actual: A): A
 export function eq<A> (expected: A): (actual: A) => A
 
+export function is<A> (expected: A, actual: A): A
+export function is<A> (expected: A): (actual: A) => A
+
 export function assert (b: boolean): boolean
 
 export function fail (message: string): never
+export function failAt (fn: Function, message: string): never
 
 export class AssertionError extends Error {
-  constructor (message: string, stackTop: Function)
+  constructor (message: string)
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,6 @@ export function is<A> (expected: A): (actual: A) => A
 export function assert (b: boolean): boolean
 
 export function fail (message: string): never
-export function failAt (fn: Function, message: string): never
 
 export class AssertionError extends Error {
   constructor (message: string)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { curry2 } from '@most/prelude'
 import { AssertionError } from './AssertionError'
-import isEqual from 'lodash.isequal'
+import { default as isEqual } from 'lodash-es/isEqual'
 export { AssertionError }
 
 // Value equality: assert structural equivalence

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,42 @@
 import { curry2 } from '@most/prelude'
 import { AssertionError } from './AssertionError'
+import isEqual from 'lodash.isequal'
 export { AssertionError }
 
-// Assert expected === actual.
+// Value equality: assert structural equivalence
 // If so, return actual, otherwise throw AssertionError
 export const eq = curry2((expected, actual) =>
+  isEqual(expected, actual)
+    ? actual
+    : fail(`eq(${expected}, ${actual})`))
+
+// Referential equality: assert expected === actual.
+// If so, return actual, otherwise throw AssertionError
+export const is = curry2((expected, actual) =>
   expected === actual
     ? actual
-    : fail(`${expected} !== ${actual}`))
+    : fail(`${expected} === ${actual}`))
 
 // Assert b is true.
 // If so, return b, otherwise throw AssertionError
-export const assert = eq(true)
+export const assert = is(true)
 
-// Throw an AssertionError with a stack trace that ends at
-// the provided stackTop function, and the provided message.
+// Throw an AssertionError with the provided message.
 // Useful for implementing new assertions.
-export const fail = message => {
-  throw new AssertionError(message, '@most/prelude')
+export const fail = message =>
+  failAt(fail, message)
+
+// Throw an AssertionError with the provided message.
+// On v8, the call stack will be trimmed at the provided
+// function.
+// Useful for implementing new assertions.
+export const failAt = (fn, message) => {
+  const e = new AssertionError(message)
+
+  /* istanbul ignore next */
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(e, fn)
+  }
+
+  throw e
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -8,7 +8,6 @@ declare export function is<A> (expected: A): (actual: A) => A
 declare export function assert (b: boolean): boolean
 
 declare export function fail (message: string): void
-declare export function failAt (fn: Function, message: string): void
 
 declare export class AssertionError {
   constructor (message: string): this

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,11 +1,15 @@
 // @flow
-declare export function assert (b: boolean): boolean
-
 declare export function eq<A> (expected: A, actual: A): A
 declare export function eq<A> (expected: A): (actual: A) => A
 
+declare export function is<A> (expected: A, actual: A): A
+declare export function is<A> (expected: A): (actual: A) => A
+
+declare export function assert (b: boolean): boolean
+
 declare export function fail (message: string): void
+declare export function failAt (fn: Function, message: string): void
 
 declare export class AssertionError {
-  constructor (message: string, stackTop: Function): this
+  constructor (message: string): this
 }

--- a/test/AssertionError-test.js
+++ b/test/AssertionError-test.js
@@ -1,6 +1,5 @@
 import { describe, it } from 'mocha'
-import { eq, assert } from '../src/index'
-import { AssertionError } from '../src/AssertionError'
+import { eq, assert, AssertionError } from '..'
 
 describe('AssertionError', () => {
   it('should be an Error', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,30 +1,54 @@
 import { describe, it } from 'mocha'
-import { fail, eq, assert, AssertionError } from '../src/index'
+import { eq, is, assert, AssertionError, fail, failAt } from '../src/index'
 
-describe('fail', () => {
-  it('should throw AssertionError with message', () => {
-    const message = `${Math.random()}`
-    try {
-      fail(message)
-    } catch(e) {
-      assertIsAssertionError(e)
-      eq(message, e.message)
-    }
+describe('eq', () => {
+  it('should pass for equal primitives', () => {
+    eq(1, eq(1, 1))
+    eq(0, eq(0, 0))
+    eq(-0, eq(-0, -0))
+    eq(0, eq(-0, 0))
+    eq('1', eq('1', '1'))
+    eq(true, eq(true, true))
+    eq(false, eq(false, false))
+  })
+
+  it('should fail for non-equal primitives', () => {
+    throwsAssertionError(eq(1), 0)
+    throwsAssertionError(eq('1'), '0')
+    throwsAssertionError(eq(true), false)
+  })
+
+  const a1 = { value: 'a' }
+  const a2 = { value: 'a'}
+  const b = { value: 'b' }
+  const c = {}
+  const d = { value: 'd', extra: 'test' }
+
+  it('should pass for equivalent objects', () => {
+    eq(a1, eq(a1, a1))
+    eq(a1, eq(a1, a2))
+    eq(a1, eq(a1)(a2))
+  })
+
+  it('should fail for non-equivalent objects', () => {
+    throwsAssertionError(eq(a1), b)
+    throwsAssertionError(eq(a1), c)
+    throwsAssertionError(eq(a1), d)
   })
 })
 
-describe('eq', () => {
+describe('is', () => {
   const a = {}
 
-  it('should pass when strictly equal', () => {
-    eq(a, eq(a, a))
-    eq(a, eq(a)(a))
+  it('should pass for strictly equal', () => {
+    is(a, is(a, a))
+    is(a, is(a)(a))
   })
 
-  it('should throw AssertionError for not equal', () => {
-    throwsAssertionError(eq(1), 2)
-    throwsAssertionError(eq(1), '1')
-    throwsAssertionError(eq({}), {})
+  it('should fail for not equal', () => {
+    throwsAssertionError(is(1), 2)
+    throwsAssertionError(is(1), '1')
+    throwsAssertionError(is({}), {})
   })
 })
 
@@ -33,8 +57,49 @@ describe('assert', () => {
     assert(true)
   })
 
-  it('should throw AssertionError for false', () => {
+  it('should fail for truthy', () => {
+    throwsAssertionError(assert, 1)
+    throwsAssertionError(assert, 'true')
+    throwsAssertionError(assert, {})
+    throwsAssertionError(assert, [])
+  })
+
+  it('should fail for false and falsy', () => {
     throwsAssertionError(assert, false)
+    throwsAssertionError(assert, 0)
+    throwsAssertionError(assert, '')
+    throwsAssertionError(assert, null)
+    throwsAssertionError(assert, undefined)
+  })
+})
+
+describe('fail', () => {
+  it('should fail with message', () => {
+    const message = `${Math.random()}`
+    try {
+      fail(message)
+      fail('Expected AssertionError')
+    } catch(e) {
+      assertIsAssertionError(e)
+      eq(message, e.message)
+    }
+  })
+})
+
+describe('failAt', () => {
+  it('should fail with message', () => {
+    const message = `${Math.random()}`
+    function test (message) {
+      failAt(test, message)
+    }
+
+    try {
+      test(message)
+      fail('Expected AssertionError')
+    } catch(e) {
+      assertIsAssertionError(e)
+      eq(message, e.message)
+    }
   })
 })
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,5 @@
 import { describe, it } from 'mocha'
-import { eq, is, assert, AssertionError, fail, failAt } from '../src/index'
+import { eq, is, assert, AssertionError, fail, failAt } from '..'
 
 describe('eq', () => {
   it('should pass for equal primitives', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,6 +1454,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+lodash-es@^4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -1492,10 +1496,6 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.keys@^3.0.0:
   version "3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"


### PR DESCRIPTION
Make `eq()` compare _value equivalence_.  Add `is()` for referential equivalence.  See API docs in README for details.  Value equivalence (eq) uses [lodash isEqual](https://lodash.com/docs/#isEqual) under the hood.