### PR TITLE
feat(throws): Add throws(), composable assertion that a function throws

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ assert(1 === '1') //> AssertionError
 assert(1) //> AssertionError (1 !== true)
 ```
 
-### throws :: (a &rarr; *) &rarr; e
+### throws :: (() &rarr; *) &rarr; e
 
 Assert that a function throws.  If so, return the thrown value, otherwise throw AssertionError.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # assert
 
-Composable, Strongly typed, curried test assertions. Use with any test framework that understands assertions that throw.
+Composable, strongly typed, curried test assertions. Use with any test framework that understands assertions that throw.
 
 ```js
 import { eq, is, assert } from '@briancavalier/assert'
@@ -30,7 +30,17 @@ yarn add --dev @briancavalier/assert
 
 ## API
 
-All functions are curried.
+All functions with arity > 1 are curried, and can be partially.  This makes for compact and convenient assertions:
+ 
+```js
+// Assert that a promise fulfills with 123 by
+// partially applying eq()
+const eq123 = eq(123)
+promise.then(eq123)
+
+// Or simply:
+promise.then(eq(123))
+```
 
 ### eq :: a &rarr; a &rarr; a
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn add --dev @briancavalier/assert
 
 ## API
 
-All functions with arity > 1 are curried, and can be partially.  This makes for compact and convenient assertions:
+All functions with arity > 1 are curried, and can be partially applied.  This makes for compact and convenient assertions:
  
 ```js
 // Assert that a promise fulfills with 123 by

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # assert
 
-Strongly typed, curried test assertions. Use with any test framework that understands assertions that throw.
+Composable, Strongly typed, curried test assertions. Use with any test framework that understands assertions that throw.
 
 ```js
 import { eq, is, assert } from '@briancavalier/assert'
@@ -71,6 +71,41 @@ assert(1 === 1) //> true
 assert(false) //> AssertionError
 assert(1 === '1') //> AssertionError
 assert(1) //> AssertionError (1 !== true)
+```
+
+### throws :: (a &rarr; *) &rarr; e
+
+Assert that a function throws.  If so, return the thrown value, otherwise throw AssertionError.  Compose
+
+```js
+throws(() => { throw new Error('oops') }) //> *returns* Error: oops
+
+throws(() => {}) //> *throws* AssertionError
+```
+
+Make assertions on the thrown value via composition:
+
+```js
+// Import your favorite function composition lib
+import { pipe } from 'ramda'
+import { is, throws } from '@briancavalier/assert'
+
+const expectedError = new Error('expected')
+
+// Compose new assertion that a function throws expectedError
+const throwsExpected = pipe(throws, is(expectedError))
+
+const f = () => {
+  throw expectedError
+}
+
+throwsExpected(f) //> PASS, returns expectedError
+
+const g = () => {
+  throw new Error('this should fail')
+}
+
+throwsExpected(g) //> FAIL, throws AssertionError
 ```
 
 ### fail :: string &rarr; void

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ assert(1) //> AssertionError (1 !== true)
 
 ### throws :: (a &rarr; *) &rarr; e
 
-Assert that a function throws.  If so, return the thrown value, otherwise throw AssertionError.  Compose
+Assert that a function throws.  If so, return the thrown value, otherwise throw AssertionError.
 
 ```js
 throws(() => { throw new Error('oops') }) //> *returns* Error: oops

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ assert(1 === '1') //> AssertionError
 assert(1) //> AssertionError (1 !== true)
 ```
 
-### throws :: (() &rarr; *) &rarr; e
+### throws :: (Error e) &rArr; (() &rarr; *) &rarr; e
 
 Assert that a function throws.  If so, return the thrown value, otherwise throw AssertionError.
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,8 @@ export function is<A> (expected: A): (actual: A) => A
 
 export function assert (b: boolean): boolean
 
+export function throws<E> (f: () => any): E
+
 export function fail (message: string): never
 
 export class AssertionError extends Error {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,7 @@ export function is<A> (expected: A): (actual: A) => A
 
 export function assert (b: boolean): boolean
 
-export function throws<E> (f: () => any): E
+export function throws <E extends Error> (f: () => any): E
 
 export function fail (message: string): never
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,18 @@ export const is = curry2((expected, actual) =>
 // If so, return b, otherwise throw AssertionError
 export const assert = is(true)
 
+// Assert f throws. If so, return the thrown value,
+// otherwise throw AssertionError.
+export const throws = f => {
+  let x
+  try {
+    x = f()
+  } catch (e) {
+    return e
+  }
+  fail(`did not throw, returned ${x}`)
+}
+
 // Throw an AssertionError with the provided message.
 // Useful for implementing new assertions.
 export const fail = message =>

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -7,7 +7,7 @@ declare export function is<A> (expected: A): (actual: A) => A
 
 declare export function assert (b: boolean): boolean
 
-declare export function throws <E> (f: () => any): E
+declare export function throws <E: Error> (f: () => any): E
 
 declare export function fail (message: string): void
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -7,6 +7,8 @@ declare export function is<A> (expected: A): (actual: A) => A
 
 declare export function assert (b: boolean): boolean
 
+declare export function throws <E> (f: () => any): E
+
 declare export function fail (message: string): void
 
 declare export class AssertionError {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,5 @@
 import { describe, it } from 'mocha'
-import { eq, is, assert, AssertionError, fail, failAt } from '..'
+import { eq, is, assert, throws, fail, failAt, AssertionError } from '..'
 
 describe('eq', () => {
   it('should pass for equal primitives', () => {
@@ -70,6 +70,17 @@ describe('assert', () => {
     throwsAssertionError(assert, '')
     throwsAssertionError(assert, null)
     throwsAssertionError(assert, undefined)
+  })
+})
+
+describe('throws', () => {
+  it('should pass when f throws', () => {
+    const e = new Error()
+    is(e, throws(() => { throw e }))
+  })
+
+  it('should fail when f returns', () => {
+    throwsAssertionError(throws, () => {})
   })
 })
 


### PR DESCRIPTION
AFFECTS: @briancavalier/assert

Add composable `throws` assertion, which reverses the outcome of a function: if `f` throws, return the thrown value.  If `f` returns, throw an AssertionError containing the returns value.  This allows `throws` to compose with other assertions, rather than handling various cases internally:

```js
const expected = new Error()
const throwsExpected = pipe(throws, is(expected))

throwsExpected(f)
```