### PR TITLE
feat(assert): Improve error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "commit": "northbrook commit",
-    "test": "npm run test:lint && npm run build:dist && npm run test:unit && npm run test:flow",
+    "test": "npm run test:lint && npm run test:unit && npm run test:flow",
     "test:unit": "nyc -s northbrook mocha",
     "test:lint": "northbrook eslint",
     "test:flow": "flow check",
@@ -46,10 +46,12 @@
     "nyc": "^10.1.2",
     "rollup": "^0.41.4",
     "rollup-plugin-buble": "^0.15.0",
+    "rollup-plugin-commonjs": "^7.0.0",
     "rollup-plugin-node-resolve": "^2.0.0"
   },
   "dependencies": {
     "@most/prelude": "^1.4.1",
-    "lodash-es": "^4.17.4"
+    "lodash.isequal": "^4.5.0",
+    "object-inspect": "^1.2.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,12 @@
 import buble from 'rollup-plugin-buble'
 import nodeResolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
 
 export default {
   entry: 'src/index.js',
   plugins: [
     buble(),
+    commonjs(),
     nodeResolve({
       jsnext: true
     })

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { curry2 } from '@most/prelude'
 import { AssertionError } from './AssertionError'
-import { default as isEqual } from 'lodash-es/isEqual'
+import isEqual from 'lodash.isequal'
+import inspect from 'object-inspect'
 export { AssertionError }
 
 // Value equality: assert structural equivalence
@@ -8,19 +9,19 @@ export { AssertionError }
 export const eq = curry2((expected, actual) =>
   isEqual(expected, actual)
     ? actual
-    : fail2(`eq(${expected}, ${actual})`, expected, actual))
+    : fail2(`not equivalent: eq(${inspect2(expected, actual)})`, expected, actual))
 
 // Referential equality: assert expected === actual.
 // If so, return actual, otherwise throw AssertionError
 export const is = curry2((expected, actual) =>
   expected === actual
     ? actual
-    : fail2(`${expected} === ${actual}`, expected, actual))
+    : fail2(`not same reference: is(${inspect2(expected, actual)})`, expected, actual))
 
 // Assert b is true.
 // If so, return b, otherwise throw AssertionError
 export const assert = b =>
-  b === true || fail1('assertion failed', b)
+  b === true || fail1(`not strictly true: assert(${inspect(b)})`, b)
 
 // Assert f throws. If so, return the thrown value,
 // otherwise throw AssertionError.
@@ -31,7 +32,7 @@ export const throws = f => {
   } catch (e) {
     return e
   }
-  fail1(`did not throw, returned ${x}`, x)
+  fail1(`did not throw, returned: ${inspect(x)}`, x)
 }
 
 // Throw an AssertionError with the provided value, which
@@ -55,3 +56,6 @@ const fail2 = (message, expected, actual) =>
 export const failAt = (fn, message, expected, actual) => {
   throw new AssertionError(message, expected, actual, fn)
 }
+
+// Inspect both values and join into string
+const inspect2 = (a, b) => `${inspect(a)}, ${inspect(b)}`

--- a/test/AssertionError-test.js
+++ b/test/AssertionError-test.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha'
-import { eq, is, assert, AssertionError } from '..'
+import { eq, is, assert } from '../src/index'
+import { AssertionError } from '../src/AssertionError'
 
 describe('AssertionError', () => {
   it('should be an Error', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha'
-import { eq, is, assert, throws, fail, failAt, AssertionError } from '..'
+import { eq, is, assert, throws, fail, failAt } from '../src/index'
+import { AssertionError } from '../src/AssertionError'
 
 describe('eq', () => {
   it('should pass for equal primitives', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,10 @@ estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
 
+estree-walker@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.0.tgz#f67ca8f57b9ed66d886af816c099c779b315d4db"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -1454,10 +1458,6 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-lodash-es@^4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
-
 lodash._baseassign@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz#8c38a099500f215ad09e59f1722fd0c52bfe0a4e"
@@ -1496,6 +1496,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -1544,6 +1548,12 @@ lru-cache@^4.0.1:
 magic-string@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.14.0.tgz#57224aef1701caeed273b17a39a956e72b172462"
+  dependencies:
+    vlq "^0.2.1"
+
+magic-string@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.19.0.tgz#198948217254e3e0b93080e01146b7c73b2a06b2"
   dependencies:
     vlq "^0.2.1"
 
@@ -1681,35 +1691,7 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
-northbrook@^4.3.5:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/northbrook/-/northbrook-4.5.3.tgz#dbf7224b3f2e3d560eeff6c144a77f0226db303e"
-  dependencies:
-    "@typed/sequence" "^1.1.0"
-    "@types/findup-sync" "^0.3.29"
-    "@types/minimist" "^1.1.29"
-    "@types/mkdirp" "^0.3.29"
-    "@types/node" "^6.0.52"
-    "@types/ramda" "0.0.2"
-    "@types/rimraf" "^0.0.28"
-    "@types/semver" "^5.3.30"
-    app-module-path "^2.1.0"
-    buba "^4.0.2"
-    dependency-graph "^0.5.0"
-    findup-sync "^0.4.3"
-    mkdirp "^0.5.1"
-    ramda "^0.22.1"
-    reginn "^2.1.4"
-    rimraf "^2.5.4"
-    semver "^5.3.0"
-    simple-spinner "0.0.5"
-    stdio-mock "^1.1.0"
-    ts-node "^2.0.0"
-    typed-colors "^1.0.0"
-    typed-figures "^1.0.0"
-    typed-prompts "^1.4.0"
-
-northbrook@^4.5.5:
+northbrook@^4.3.5, northbrook@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/northbrook/-/northbrook-4.5.5.tgz#5f19b0eb310886c7ea84522099fddb5b815a63c7"
   dependencies:
@@ -1776,6 +1758,10 @@ nyc@^10.1.2:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.1.tgz#3b62226eb8f6d441751c7d8f22a20ff80ac9dc3f"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2048,7 +2034,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6:
+resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
 
@@ -2078,6 +2064,16 @@ rollup-plugin-buble@^0.15.0:
     buble "^0.15.0"
     rollup-pluginutils "^1.5.0"
 
+rollup-plugin-commonjs@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-7.0.0.tgz#510762d5c423c761cd16d8e8451715b39f0ceb08"
+  dependencies:
+    acorn "^4.0.1"
+    estree-walker "^0.3.0"
+    magic-string "^0.19.0"
+    resolve "^1.1.7"
+    rollup-pluginutils "^1.5.1"
+
 rollup-plugin-node-resolve@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.0.0.tgz#07e0ae94ac002a3ea36e8f33ca121d9f836b1309"
@@ -2086,7 +2082,7 @@ rollup-plugin-node-resolve@^2.0.0:
     builtin-modules "^1.1.0"
     resolve "^1.1.6"
 
-rollup-pluginutils@^1.5.0:
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:


### PR DESCRIPTION
AFFECTS: @briancavalier/assert

Inspect values with [object-inspect](https://github.com/substack/object-inspect), and add leading hints about why the assertion failed.  Also, switched to commonjs `lodash.isequal`.  It results in a slightly smaller build, ironically.

Examples of new messages, using mocha:

<img width="553" alt="screen shot 2017-01-25 at 9 00 53 am" src="https://cloud.githubusercontent.com/assets/90518/22293223/cfa6c8d2-e2dc-11e6-9396-3ba94b2a8a09.png">

<img width="558" alt="screen shot 2017-01-25 at 9 01 45 am" src="https://cloud.githubusercontent.com/assets/90518/22293249/f1f49086-e2dc-11e6-85c6-fdb92d441eb6.png">

<img width="469" alt="screen shot 2017-01-25 at 8 59 50 am" src="https://cloud.githubusercontent.com/assets/90518/22293199/b126493c-e2dc-11e6-8844-43929c1ac994.png">
