### PR TITLE
feat(where): Add where() to lift predicates into assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,53 @@ it('rejects with expectedError', () => {
 })
 ```
 
+### where :: (a &rarr; boolean) &rarr; a &rarr; a
+
+Assert that a unary predicate holds.  Provides customization: Lift a unary predicate into an assertion, allowing you to create custom assertions.
+
+```js
+const t = new Thing()
+where(x => x instanceof Thing, t) //> t
+where(x => x instanceof Thing, {}) //> AssertionError
+
+// Partially apply to create custom assertions
+const assertIsAThing = where(x => x instanceof Thing)
+assertIsAThing(t) //> t
+assertIsAThing(123) //> AssertionError
+```
+
+### where2 :: (a &rarr; b &rarr; boolean) &rarr; a &rarr; b &rarr; b
+
+Assert that a binary predicate holds.  Provides customization: Lift a binary predicate into an assertion, allowing you to create custom assertions.
+
+```js
+const lessThan = (a, b) => b < a
+where2(lessThan, 10, 9) //> 9
+where2(lessThan, 10, 11) //> AssertionError
+
+// Partially apply to create custom assertions
+// Custom assertLessThan
+const assertLessThan = where2(lessThan)
+assertLessThan(10, 9) //> 9
+assertLessThan(10, 11) //> AssertionError
+Promise.resolve(9).then(assertLessThan(10)) //> fulfilled: 9
+Promise.resolve(11).then(assertLessThan(10)) //> rejected: AssertionError
+
+// Custom assertInstanceOf
+const instanceOf = (a, b) => b instanceof a
+const assertInstanceOf = where2(instanceOf)
+
+const t = new Thing()
+assertInstanceOf(Thing, t) //> t
+assertInstanceOf(Thing, {}) //> AssertionError
+
+// Further partially apply Constructor type to create
+// specific assertInstanceOfThing
+const assertInstanceOfThing = assertInstanceOf(Thing) 
+assertInstanceOfThing(t) //> t
+assertInstanceOfThing({}) //> AssertionError
+```
+
 ### fail :: a &rarr; void
 
 Throw an `AssertionError` with the provided message, which will be coerced to a string and used as the error message. Useful for implementing new assertions.

--- a/README.md
+++ b/README.md
@@ -142,33 +142,18 @@ it('rejects with expectedError', () => {
 })
 ```
 
-### where :: (a &rarr; boolean) &rarr; a &rarr; a
+### where :: (a &rarr; b &rarr; boolean) &rarr; a &rarr; b &rarr; b
 
-Assert that a unary predicate holds.  Provides customization: Lift a unary predicate into an assertion, allowing you to create custom assertions.
-
-```js
-const t = new Thing()
-where(x => x instanceof Thing, t) //> t
-where(x => x instanceof Thing, {}) //> AssertionError
-
-// Partially apply to create custom assertions
-const assertIsAThing = where(x => x instanceof Thing)
-assertIsAThing(t) //> t
-assertIsAThing(123) //> AssertionError
-```
-
-### where2 :: (a &rarr; b &rarr; boolean) &rarr; a &rarr; b &rarr; b
-
-Assert that a binary predicate holds.  Provides customization: Lift a binary predicate into an assertion, allowing you to create custom assertions.
+Assert that a binary predicate holds.  Lift a binary predicate into an assertion, allowing you to create custom assertions.
 
 ```js
 const lessThan = (a, b) => b < a
-where2(lessThan, 10, 9) //> 9
-where2(lessThan, 10, 11) //> AssertionError
+where(lessThan, 10, 9) //> 9
+where(lessThan, 10, 11) //> AssertionError
 
 // Partially apply to create custom assertions
 // Custom assertLessThan
-const assertLessThan = where2(lessThan)
+const assertLessThan = where(lessThan)
 assertLessThan(10, 9) //> 9
 assertLessThan(10, 11) //> AssertionError
 Promise.resolve(9).then(assertLessThan(10)) //> fulfilled: 9
@@ -176,7 +161,7 @@ Promise.resolve(11).then(assertLessThan(10)) //> rejected: AssertionError
 
 // Custom assertInstanceOf
 const instanceOf = (a, b) => b instanceof a
-const assertInstanceOf = where2(instanceOf)
+const assertInstanceOf = where(instanceOf)
 
 const t = new Thing()
 assertInstanceOf(Thing, t) //> t

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-node-resolve": "^2.0.0"
   },
   "dependencies": {
-    "@most/prelude": "^1.4.1",
+    "@most/prelude": "^1.5.0",
     "lodash.isequal": "^4.5.0",
     "object-inspect": "^1.2.1"
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,13 +1,9 @@
-export type Predicate<A> = (a: A) => boolean
 export type Predicate2<A, B> = (a: A, b: B) => boolean
 
-export function where<A> (p: Predicate<A>, a: A): A
-export function where<A> (p: Predicate<A>): (a: A) => A
-
-export function where2<A, B> (p: Predicate2<A, B>, a: A, b: B): A
-export function where2<A, B> (p: Predicate2<A, B>): (a: A, b: B) => A
-export function where2<A, B> (p: Predicate2<A, B>, a: A): (b: B) => A
-export function where2<A, B> (p: Predicate2<A, B>): (a: A) => (b: B) => A
+export function where<A, B> (p: Predicate2<A, B>, a: A, b: B): B
+export function where<A, B> (p: Predicate2<A, B>): (a: A, b: B) => B
+export function where<A, B> (p: Predicate2<A, B>, a: A): (b: B) => B
+export function where<A, B> (p: Predicate2<A, B>): (a: A) => (b: B) => B
 
 export function eq<A> (expected: A, actual: A): A
 export function eq<A> (expected: A): (actual: A) => A

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,14 @@
+export type Predicate<A> = (a: A) => boolean
+export type Predicate2<A, B> = (a: A, b: B) => boolean
+
+export function where<A> (p: Predicate<A>, a: A): A
+export function where<A> (p: Predicate<A>): (a: A) => A
+
+export function where2<A, B> (p: Predicate2<A, B>, a: A, b: B): A
+export function where2<A, B> (p: Predicate2<A, B>): (a: A, b: B) => A
+export function where2<A, B> (p: Predicate2<A, B>, a: A): (b: B) => A
+export function where2<A, B> (p: Predicate2<A, B>): (a: A) => (b: B) => A
+
 export function eq<A> (expected: A, actual: A): A
 export function eq<A> (expected: A): (actual: A) => A
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { curry2, curry3, id } from '@most/prelude'
+import { curry3, curry4, id } from '@most/prelude'
 import { AssertionError } from './AssertionError'
 import isEqual from 'lodash.isequal'
 import inspect from 'object-inspect'

--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,6 @@ const fail1 = (message, actual) =>
 const fail2 = (message, expected, actual) =>
   failAt(fail2, message, expected, actual)
 
-// Throw an AssertionError with the provided message, expected,
-// and actual values.
 // Throw an AssertionError with the provided message.
 // On v8, the call stack will be trimmed at the provided
 // function.

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,14 @@ import isEqual from 'lodash.isequal'
 import inspect from 'object-inspect'
 export { AssertionError }
 
-const sameRef = (a, b) => a === b
-
+// Base assertion function.  Lifts a failure message and binary
+// predicate to an assertion.
 const _where = curry4((m, p2, a, b) =>
   p2(a, b) === true ? b
     : fail2(`${m}${inspectPredicate(p2)}(${inspect2(a, b)})`, a, b))
+
+// References comparison helper
+const sameRef = (a, b) => a === b
 
 // Assert a binary predicate holds
 // Given a predicate p, return an assertion that passes if

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { curry3, curry4, id } from '@most/prelude'
+import { curry4, id } from '@most/prelude'
 import { AssertionError } from './AssertionError'
 import isEqual from 'lodash.isequal'
 import inspect from 'object-inspect'
@@ -6,35 +6,26 @@ export { AssertionError }
 
 const sameRef = (a, b) => a === b
 
-const _where = curry3((m, p, a) =>
-  p(a) === true ? a
-    : fail1(_where, `${m}${inspectPredicate(p)}(${inspect(a)})`, a))
-
-const _where2 = curry4((m, p2, a, b) =>
+const _where = curry4((m, p2, a, b) =>
   p2(a, b) === true ? b
     : fail2(`${m}${inspectPredicate(p2)}(${inspect2(a, b)})`, a, b))
 
-// Assert a unary boolean predicate holds
+// Assert a binary predicate holds
 // Given a predicate p, return an assertion that passes if
-// p(a) holds, and throws AssertionError otherwise
+// p(a, b) holds, and throws AssertionError otherwise
 export const where = _where('failed: ')
-
-// Assert a binary boolean predicate holds
-// Given a predicate p2, return an assertion that passes if
-// p2(a, b) holds, and throws AssertionError otherwise
-export const where2 = _where2('failed: ')
 
 // Value equality: assert structural equivalence
 // If so, return actual, otherwise throw AssertionError
-export const eq = _where2('not equal: ', isEqual)
+export const eq = _where('not equal: ', isEqual)
 
 // Referential equality: assert expected === actual.
 // If so, return actual, otherwise throw AssertionError
-export const is = _where2('not same reference: ', sameRef)
+export const is = _where('not same reference: ', sameRef)
 
 // Assert b is true.
 // If so, return b, otherwise throw AssertionError
-export const assert = _where('not true: ', id)
+export const assert = _where('not true: ', sameRef, true)
 
 // Assert f throws. If so, return the thrown value,
 // otherwise throw AssertionError.

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,15 @@
 // @flow
+export type Predicate<A> = (A) => boolean
+export type Predicate2<A, B> = (A, B) => boolean
+
+declare export function where<A> (p: Predicate<A>, a: A): A
+declare export function where<A> (p: Predicate<A>): (a: A) => A
+
+declare export function where2<A, B> (p: Predicate2<A, B>, a: A, b: B): A
+declare export function where2<A, B> (p: Predicate2<A, B>): (a: A, b: B) => A
+declare export function where2<A, B> (p: Predicate2<A, B>, a: A): (b: B) => A
+declare export function where2<A, B> (p: Predicate2<A, B>): (a: A) => (b: B) => A
+
 declare export function eq<A> (expected: A, actual: A): A
 declare export function eq<A> (expected: A): (actual: A) => A
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,14 +1,10 @@
 // @flow
-export type Predicate<A> = (A) => boolean
 export type Predicate2<A, B> = (A, B) => boolean
 
-declare export function where<A> (p: Predicate<A>, a: A): A
-declare export function where<A> (p: Predicate<A>): (a: A) => A
-
-declare export function where2<A, B> (p: Predicate2<A, B>, a: A, b: B): A
-declare export function where2<A, B> (p: Predicate2<A, B>): (a: A, b: B) => A
-declare export function where2<A, B> (p: Predicate2<A, B>, a: A): (b: B) => A
-declare export function where2<A, B> (p: Predicate2<A, B>): (a: A) => (b: B) => A
+declare export function where<A, B> (p: Predicate2<A, B>, a: A, b: B): B
+declare export function where<A, B> (p: Predicate2<A, B>): (A, B) => B
+declare export function where<A, B> (p: Predicate2<A, B>, a: A): (B) => B
+declare export function where<A, B> (p: Predicate2<A, B>): (A) => (B) => B
 
 declare export function eq<A> (expected: A, actual: A): A
 declare export function eq<A> (expected: A): (actual: A) => A

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,6 +1,26 @@
 import { describe, it } from 'mocha'
-import { eq, is, assert, throws, rejects, fail, failAt } from '../src/index'
+import { where, where2, eq, is, assert, throws, rejects, fail, failAt } from '../src/index'
 import { AssertionError } from '../src/AssertionError'
+
+describe('where', () => {
+  it('should pass when predicate is true', () => {
+    eq(1, where(x => x === 1, 1))
+  })
+
+  it('should fail when predicate is false', () => {
+    throwsAssertionError(where(x => false), 1)
+  })
+})
+
+describe('where2', () => {
+  it('should pass when predicate is true', () => {
+    eq(1, where2((a, b) => a === b, 1, 1))
+  })
+
+  it('should fail when predicate is false', () => {
+    throwsAssertionError(where2((a, b) => a === b, 1), 2)
+  })
+})
 
 describe('eq', () => {
   it('should pass for equal primitives', () => {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,24 +1,14 @@
 import { describe, it } from 'mocha'
-import { where, where2, eq, is, assert, throws, rejects, fail, failAt } from '../src/index'
+import { where, eq, is, assert, throws, rejects, fail, failAt } from '../src/index'
 import { AssertionError } from '../src/AssertionError'
 
 describe('where', () => {
   it('should pass when predicate is true', () => {
-    eq(1, where(x => x === 1, 1))
+    eq(1, where((a, b) => a === b, 1, 1))
   })
 
   it('should fail when predicate is false', () => {
-    throwsAssertionError(where(x => false), 1)
-  })
-})
-
-describe('where2', () => {
-  it('should pass when predicate is true', () => {
-    eq(1, where2((a, b) => a === b, 1, 1))
-  })
-
-  it('should fail when predicate is false', () => {
-    throwsAssertionError(where2((a, b) => a === b, 1), 2)
+    throwsAssertionError(where((a, b) => a === b, 1), 2)
   })
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@most/prelude@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.4.1.tgz#b940b5563096f27637401618a5351f42466ea8f3"
+"@most/prelude@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.5.0.tgz#0c8ce09f305039d4055d3deb59c9e44cd337854d"
 
 "@northbrook/eslint@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
AFFECTS: @briancavalier/assert

Add where().  Lift binary predicates to assertions.  Encode other existing assertions using where().

Requires `curry4`, which `@most/prelude` doesn't provide yet--see mostjs/prelude#12

### Todo

- [x] Merge mostjs/prelude#12 and use its `curry4`
- [x] Docs

Close #7 